### PR TITLE
Return card mode even when network is down

### DIFF
--- a/os/linux/sta_ioctl.c
+++ b/os/linux/sta_ioctl.c
@@ -268,7 +268,10 @@ int rt_ioctl_giwmode(struct net_device *dev,
 	if (RTMP_DRIVER_IOCTL_SANITY_CHECK(pAd, NULL) != NDIS_STATUS_SUCCESS)
     {
         DBGPRINT(RT_DEBUG_TRACE, ("INFO::Network is down!\n"));
-        return -ENETDOWN;   
+		// callers like NetworkManager expect to be able to read a valid mode
+		// even when down
+		*mode = IW_MODE_INFRA;
+		return 0;
     }
 
 


### PR DESCRIPTION
Required for NetworkManager to work with Kernel >= 4.4.74+.

Fixes https://github.com/chenhaiq/mt7610u_wifi_sta_v3002_dpo_20130916/issues/30

Tested with TP-Link Archer T2U and kernel module mt7650u_sta

@chenhaiq 